### PR TITLE
vuart_write_data() now clears the VUART_TRANSMIT_COMPLETE flag

### DIFF
--- a/src/vuart.c
+++ b/src/vuart.c
@@ -243,7 +243,7 @@ void vuart_write_data(uint8_t data)
 {
     while(!(vuart_state & (1 << VUART_DATA_EMPTY)));
 
-    vuart_state &= ~(1 << VUART_DATA_EMPTY);
+    vuart_state &= ~(1 << VUART_TRANSMIT_COMPLETE | 1 << VUART_DATA_EMPTY);
     tx_data = data;
     tx_bit_count = 0;
 


### PR DESCRIPTION
Hello and thanks for your work!

The VUART_TRANSMIT_COMPLETE flag isn't cleared anywhere. I assume it should be when queuing new data.